### PR TITLE
allow ParquetEnvelopeWriter to push data into an arbitrary stream

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -151,6 +151,15 @@ class ParquetEnvelopeWriter {
     return new ParquetEnvelopeWriter(schema, writeFn, closeFn, 0, opts);
   }
 
+  /**
+   * Create a new parquet envelope writer that writes to the specified stream
+   */
+  static async openStream(schema, outputStream, opts) {
+    let writeFn = parquet_util.oswrite.bind(undefined, outputStream);
+    let closeFn = parquet_util.osclose.bind(undefined, outputStream);
+    return new ParquetEnvelopeWriter(schema, writeFn, closeFn, 0, opts);
+  }
+
   constructor(schema, writeFn, closeFn, fileOffset, opts) {
     this.schema = schema;
     this.write = writeFn,


### PR DESCRIPTION
Will write data as usual for any stream that looks like a writable file stream, meaning that it implements the `close` method. Here's a usage example:

```
const writeStream = new stream.Writable()
writeStream._write = (chunk, encoding, done) => {done()}
writeStream.close = (callback) => {callback()}

const envelopeWriter = await parquet.ParquetEnvelopeWriter.openStream(schema, writeStream, {})
await envelopeWriter.writeHeader()

const writer = new parquet.ParquetWriter(schema, envelopeWriter, {})
```

Use cases for this feature include streaming files directly to s3