### PR TITLE
fix nested non-repeated field values overridden

### DIFF
--- a/lib/shred.js
+++ b/lib/shred.js
@@ -218,7 +218,7 @@ function materializeRecordField(record, branch, rLevels, dLevel, value) {
           dLevel,
           value);
     } else {
-      record[node.name] = {};
+      record[node.name] = record[node.name] || {};
 
       materializeRecordField(
           record[node.name],


### PR DESCRIPTION
When using a nested field which isn't repeated, only the last field is preserved after a read operation.

For example:
```
let json = {
    "message_id": "2e1a346a-1faf-4ec6-bf8b-32ccc27cf2c4",
    "timestamp": {
      "seconds": 1513802930,
      "nanos": 585333000
    }
}
```

The output after a read will be:
```
let json = {
    "message_id": "2e1a346a-1faf-4ec6-bf8b-32ccc27cf2c4",
    "timestamp": {
      "nanos": 585333000 // missing       "seconds": 1513802930
    }
}
```
