### PR TITLE
Execute all readColumnChunk concurrently for a given RowGroup

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -220,6 +220,8 @@ class ParquetEnvelopeReader {
       columnData: {}
     };
 
+    let requests = [];
+
     for (let colChunk of rowGroup.columns) {
       const colMetadata = colChunk.meta_data;
       const colKey = colMetadata.path_in_schema;
@@ -228,8 +230,16 @@ class ParquetEnvelopeReader {
         continue;
       }
 
-      buffer.columnData[colKey] = await this.readColumnChunk(schema, colChunk);
+      requests.push(this.readColumnChunk(schema, colChunk).then(payload => ({
+        colKey, payload
+      })));
     }
+
+    let data = await Promise.all(requests);
+
+    data.forEach(d => {
+      buffer.columnData[d.colKey] = d.payload;
+    });
 
     return buffer;
   }


### PR DESCRIPTION
Offers significant speed improvement when the reader has slow i/o (over network instead of from disk)