### PR TITLE
Don't error if an optional value is `undefined` or `null`

### DIFF
--- a/lib/shred.js
+++ b/lib/shred.js
@@ -79,7 +79,7 @@ function shredRecordInternal(fields, record, data, rlvl, dlvl) {
 
     // fetch values
     let values = [];
-    if (record && (fieldName in record)) {
+    if (record && (fieldName in record) && record[fieldName] !== undefined && record[fieldName] !== null) {
       if (record[fieldName].constructor === Array) {
         values = record[fieldName];
       } else {

--- a/test/integration.js
+++ b/test/integration.js
@@ -68,6 +68,7 @@ function mkTestRows(opts) {
     rows.push({
       name: 'kiwi',
       price: 4.2,
+      quantity: undefined,
       day: new Date('2017-11-26'),
       date: new Date(TEST_VTIME + 8000 * i),
       finger: "FNORD",


### PR DESCRIPTION
closes https://github.com/ironSource/parquetjs/issues/36

Property values that are `undefined` or `null` are treated as if they don't exists on the record.  
Amended the integration test to check the fix