### PR TITLE
export `shred.materializePath`

### DIFF
--- a/lib/shred.js
+++ b/lib/shred.js
@@ -155,44 +155,46 @@ function shredRecordInternal(fields, record, data, rlvl, dlvl) {
  *
  */
 exports.materializeRecords = function(schema, buffer) {
-  let records = [];
-  for (let i = 0; i < buffer.rowCount; ++i) {
-    records.push({});
-  }
+  let records;
 
   for (let k in buffer.columnData) {
     const field = schema.findField(k);
     const fieldBranch = schema.findFieldBranch(k);
-    let values = buffer.columnData[k].values[Symbol.iterator]();
-
-    let rLevels = new Array(field.rLevelMax + 1);
-    rLevels.fill(0);
-
-    for (let i = 0; i < buffer.columnData[k].count; ++i) {
-      const dLevel = buffer.columnData[k].dlevels[i];
-      const rLevel = buffer.columnData[k].rlevels[i];
-
-      rLevels[rLevel]++;
-      rLevels.fill(0, rLevel + 1);
-
-      let value = null;
-      if (dLevel === field.dLevelMax) {
-        value = parquet_types.fromPrimitive(
-            field.originalType || field.primitiveType,
-            values.next().value);
-      }
-
-      materializeRecordField(
-          records[rLevels[0] - 1],
-          fieldBranch,
-          rLevels.slice(1),
-          dLevel,
-          value);
-    }
+    records = exports.materializePath(field, fieldBranch, buffer.columnData[k], buffer.rowCount, records);
   }
 
   return records;
-}
+};
+
+exports.materializePath = function(field, fieldBranch, data, rowCount, records) {
+  records = records || [...Array(rowCount)].map( () => ({}));
+  let values = data.values[Symbol.iterator]();
+  let rLevels = new Array(field.rLevelMax + 1);
+  rLevels.fill(0);
+
+  for (let i = 0; i < data.count; ++i) {
+    const dLevel = data.dlevels[i];
+    const rLevel = data.rlevels[i];
+
+    rLevels[rLevel]++;
+    rLevels.fill(0, rLevel + 1);
+
+    let value = null;
+    if (dLevel === field.dLevelMax) {
+      value = parquet_types.fromPrimitive(
+          field.originalType || field.primitiveType,
+          values.next().value);
+    }
+
+    materializeRecordField(
+        records[rLevels[0] - 1],
+        fieldBranch,
+        rLevels.slice(1),
+        dLevel,
+        value);
+  }
+  return records;
+};
 
 function materializeRecordField(record, branch, rLevels, dLevel, value) {
   const node = branch[0];


### PR DESCRIPTION
Export separately the functionality that materializes a particular path. This allows the user to materialize the records incrementally column-by-column, i.e. by first reading one column into materialize, and then later read another column (from the same page) and materialize into the same set of records.