### PR TITLE
Fix serious package vulnerabilities by updating thrift and mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "lzo": "^0.4.0",
     "object-stream": "0.0.1",
     "snappyjs": "^0.6.0",
-    "thrift": "^0.10.0",
+    "thrift": "^0.11.0",
     "varint": "^5.0.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "mocha": "^3.5.3"
+    "mocha": "^5.2.0"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
Fixes package vulnerabilities with a simple version upgrade and gets rid of annoying `run npm audit fix` message.