### PR TITLE
Replace brotli lib

### DIFF
--- a/lib/compression.js
+++ b/lib/compression.js
@@ -2,7 +2,7 @@
 const zlib = require('zlib');
 const snappy = require('snappyjs');
 const lzo = require('lzo');
-const brotli = require('brotli');
+const iltorb = require('iltorb');
 
 const PARQUET_COMPRESSION_METHODS = {
   'UNCOMPRESSED': {
@@ -55,7 +55,7 @@ function deflate_lzo(value) {
 }
 
 function deflate_brotli(value) {
-  return new Buffer(brotli.compress(value, {
+  return new Buffer(iltorb.compressSync(value, {
     mode: 0,
     quality: 8,
     lgwin: 22
@@ -90,7 +90,7 @@ function inflate_lzo(value) {
 }
 
 function inflate_brotli(value) {
-  return new Buffer(brotli.decompress(value));
+  return new Buffer(iltorb.decompressSync(value));
 }
 
 module.exports = { PARQUET_COMPRESSION_METHODS, deflate, inflate };

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "lzo": "^0.4.0",
     "object-stream": "0.0.1",
     "snappyjs": "^0.6.0",
-    "thrift": "^0.10.0",
+    "thrift": "^0.11.0",
     "varint": "^5.0.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "mocha": "^3.5.3"
+    "mocha": "^5.2.0"
   },
   "scripts": {
     "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "url": "git://github.com/ironSource/parquetjs.git"
   },
   "dependencies": {
-    "brotli": "^1.3.0",
     "bson": "^1.0.4",
+    "iltorb": "^2.4.0",
     "int53": "^0.2.4",
     "lzo": "^0.4.0",
     "object-stream": "0.0.1",


### PR DESCRIPTION
The brotli npm package causes exceptions in some environments. https://github.com/foliojs/brotli.js/issues/20
The repository is no longer being maintained so should be replaced.