### PR TITLE
make lzo optional peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To use parquet.js with node.js, install it using npm:
   $ npm install parquetjs
 ```
 
-Snappy, GZip, and Brotli compression is bundled, but if you want to use lzo 
+Snappy, GZip, and Brotli compression are bundled, but if you want to use lzo 
 then install the optional peer dependency `lzo`. `lzo` depends on native code
 so it will compile a node.js extension as part of the npm install.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ To use parquet.js with node.js, install it using npm:
   $ npm install parquetjs
 ```
 
+Snappy, GZip, and Brotli compression is bundled, but if you want to use lzo 
+then install the optional peer dependency `lzo`. `lzo` depends on native code
+so it will compile a node.js extension as part of the npm install.
+
+```
+# optionally if lzo compression is needed
+  $ npm install lzo
+```
+
 _parquet.js requires node.js >= 7.6.0_
 
 

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -1,8 +1,12 @@
 'use strict';
 const zlib = require('zlib');
 const snappy = require('snappyjs');
-const lzo = require('lzo');
 const brotli = require('brotli');
+
+// make lzo an optional peer dependency
+const codependency = require("codependency");
+const requirePeer = codependency.register(module, {strictCheck: false});
+const lzo = requirePeer("lzo", { optional: true });
 
 const PARQUET_COMPRESSION_METHODS = {
   'UNCOMPRESSED': {
@@ -17,15 +21,19 @@ const PARQUET_COMPRESSION_METHODS = {
     deflate: deflate_snappy,
     inflate: inflate_snappy
   },
-  'LZO': {
-    deflate: deflate_lzo,
-    inflate: inflate_lzo
-  },
   'BROTLI': {
     deflate: deflate_brotli,
     inflate: inflate_brotli
   }
 };
+
+// if lzo is installed add its methods
+if (lzo) {
+  PARQUET_COMPRESSION_METHODS.LZO = {
+    deflate: deflate_lzo,
+    inflate: inflate_lzo
+  };
+}
 
 /**
  * Deflate a value using compression method `method`

--- a/package.json
+++ b/package.json
@@ -17,12 +17,15 @@
   "dependencies": {
     "brotli": "^1.3.0",
     "bson": "^1.0.4",
+    "codependency": "^2.1.0",
     "int53": "^0.2.4",
-    "lzo": "^0.4.0",
     "object-stream": "0.0.1",
     "snappyjs": "^0.6.0",
     "thrift": "^0.11.0",
     "varint": "^5.0.0"
+  },
+  "optionalPeerDependencies": {
+    "lzo": "^0.4.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
Since lzo requires a native compilation step as part of its install, use codependency to make lzo an optional peer dependency and thus lzo compression (decode or encode) will not be available unless it is installed.

To enable lzo compression install the lzo package:

```bash
npm install lzo
```

This change returns this package to being a pure JS package which does not require special compilation for a target machine.