### PR TITLE
make lzo an optional dependency (alternative to pr #79)

### DIFF
--- a/lib/compression.js
+++ b/lib/compression.js
@@ -1,7 +1,6 @@
 'use strict';
 const zlib = require('zlib');
 const snappy = require('snappyjs');
-const lzo = require('lzo');
 const brotli = require('brotli');
 
 const PARQUET_COMPRESSION_METHODS = {
@@ -28,6 +27,14 @@ const PARQUET_COMPRESSION_METHODS = {
 };
 
 /**
+ * Lazyily load lzo, avoids potential failing require
+ * unless there was an attempt to access it
+ */
+function get_lzo() {
+  return require('lzo');
+}
+
+/**
  * Deflate a value using compression method `method`
  */
 function deflate(method, value) {
@@ -51,7 +58,7 @@ function deflate_snappy(value) {
 }
 
 function deflate_lzo(value) {
-  return lzo.compress(value);
+  return get_lzo().compress(value);
 }
 
 function deflate_brotli(value) {
@@ -86,7 +93,7 @@ function inflate_snappy(value) {
 }
 
 function inflate_lzo(value) {
-  return lzo.decompress(value);
+  return get_lzo().decompress(value);
 }
 
 function inflate_brotli(value) {

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "brotli": "^1.3.0",
     "bson": "^1.0.4",
     "int53": "^0.2.4",
-    "lzo": "^0.4.0",
     "object-stream": "0.0.1",
     "snappyjs": "^0.6.0",
     "thrift": "^0.11.0",
     "varint": "^5.0.0"
+  },
+  "optionalDependencies": {
+    "lzo": "^0.4.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
This is an alternative approach to #79 based on @vweevers comment.

Since lzo requires a native compilation step as part of its install make lzo an optional dependency that is only required when it is that feature is attempted to be used. We hide lzo behind a function.
