### PR TITLE
Allow zero-row files, and handle stream exceptions

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -220,10 +220,6 @@ class ParquetEnvelopeWriter {
       userMetadata = {};
     }
 
-    if (this.rowCount === 0) {
-      throw 'cannot write parquet file with zero rows';
-    }
-
     if (this.schema.fieldList.length === 0) {
       throw 'cannot write parquet file with zero fieldList';
     }

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -260,14 +260,14 @@ class ParquetTransformer extends stream.Transform {
 
   _transform(row, encoding, callback) {
     if (row) {
-      this.writer.appendRow(row).then(callback);
+      this.writer.appendRow(row).then(d => callback(null, d), callback)
     } else {
-      callback();
+      callback()
     }
   }
 
   _flush(callback) {
-    this.writer.close(callback);
+    this.writer.close(callback).then(d => callback(null, d), callback)
   }
 
 }


### PR DESCRIPTION
Creating zero-row files is uncommon, but sometimes useful for handling edge cases in a pipeline, so there's no need to arbitrarily prevent it.

The ParquetTransformer change allows exceptions to be caught and dealt with upstream when dealing with streams, previously they were being swallowed.