### PR TITLE
Improve Read Performance

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -42,6 +42,7 @@ class ParquetCursor  {
     this.columnList = columnList;
     this.rowGroup = [];
     this.rowGroupIndex = 0;
+    this.cursorIndex = 0;
   }
 
   /**
@@ -49,7 +50,7 @@ class ParquetCursor  {
    * of the file was reached
    */
   async next() {
-    if (this.rowGroup.length === 0) {
+    if (this.cursorIndex >= this.rowGroup.length) {
       if (this.rowGroupIndex >= this.metadata.row_groups.length) {
         return null;
       }
@@ -61,9 +62,10 @@ class ParquetCursor  {
 
       this.rowGroup = parquet_shredder.materializeRecords(this.schema, rowBuffer);
       this.rowGroupIndex++;
+      this.cursorIndex = 0;
     }
 
-    return this.rowGroup.shift();
+    return this.rowGroup[this.cursorIndex++];
   }
 
   /**
@@ -137,7 +139,7 @@ class ParquetReader {
     columnList = columnList.map((x) => x.constructor === Array ? x : [x]);
 
     return new ParquetCursor(
-        this.metadata, 
+        this.metadata,
         this.envelopeReader,
         this.schema,
         columnList);


### PR DESCRIPTION
Improve performance of reads by accessing the records by index instead of by .shift(). Improved read performance by 30x locally.