### PR TITLE
Fix UINT_32 conversion

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -82,7 +82,8 @@ const PARQUET_LOGICAL_TYPES = {
   'UINT_32': {
     primitiveType: 'INT32',
     originalType: 'UINT_32',
-    toPrimitive: toPrimitive_UINT32
+    toPrimitive: toPrimitive_UINT32,
+    fromPrimitive: fromPrimitive_UINT32
   },
   'UINT_64': {
     primitiveType: 'INT64',
@@ -235,7 +236,11 @@ function toPrimitive_UINT32(value) {
     throw 'invalid value for UINT32: ' + value;
   }
 
-  return v;
+  return v < 0x80000000 ? v : v - 0xffffffff;
+}
+
+function fromPrimitive_UINT32(value) {
+  return value >= 0 ? value : value + 0xffffffff;
 }
 
 function toPrimitive_INT64(value) {


### PR DESCRIPTION
Thanks for maintaining this package.
When a value of UINT_32 logical type is converted to/from an INT32 primitive, no action is taken to adjust its range. As a result, if a value >= 2^31 is encoded as UINT_32, the encoder will fail since the value is out of range of a signed INT32. Likewise, a UINT_32 read from file would be signed.
