### PR TITLE
Fixed an unhandled promise rejection on os.close

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -130,7 +130,9 @@ class ParquetWriter {
       }
 
       await this.envelopeWriter.writeFooter(this.userMetadata);
-      await this.envelopeWriter.close();
+      await this.envelopeWriter.close().catch(err => {
+        // Do nothing.  This is likely a buffer and os.close is not a function.
+      });
       this.envelopeWriter = null;
 
       if (callback) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "parquetjs",
   "description": "fully asynchronous, pure JavaScript implementation of the Parquet file format",
   "main": "parquet.js",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "homepage": "https://github.com/ironSource/parquetjs",
   "author": "ironSource <npm@ironsrc.com>",
   "license": "MIT",


### PR DESCRIPTION
If you are working with openStream, you can't close it without an unhandled promise rejection.