### PR TITLE
fix: INTERVAL type validation

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -380,7 +380,7 @@ function fromPrimitive_TIMESTAMP_MICROS(value) {
 }
 
 function toPrimitive_INTERVAL(value) {
-  if (!value.months || !value.days || !value.milliseconds) {
+  if (!('months' in value) || !('days' in value) || !('milliseconds' in value)) {
     throw "value for INTERVAL must be object { months: ..., days: ..., milliseconds: ... }";
   }
 


### PR DESCRIPTION
Permit intervals less than 1 month, 1 day, and 1 millisecond.