### PR TITLE
Fix: Maximum call stack exceeded with large data

### DIFF
--- a/lib/codec/rle.js
+++ b/lib/codec/rle.js
@@ -1,4 +1,5 @@
 const varint = require('varint')
+const parquet_util = require('../util')
 
 function encodeRunBitpacked(values, opts) {
   for (let i = 0; i < values.length % 8; i++) {
@@ -137,7 +138,7 @@ exports.decodeValues = function(type, cursor, count, opts) {
       values.push(...decodeRunBitpacked(cursor, count, opts));
     } else {
       const count = header >> 1;
-      values.push(...decodeRunRepeated(cursor, count, opts));
+      parquet_util.arrayCopy(values, ...decodeRunRepeated(cursor, count, opts));
     }
   }
   values = values.slice(0,count);

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -328,12 +328,11 @@ function decodeDataPages(buffer, opts) {
         throw "invalid page type: " + pageType;
     }
 
-    Array.prototype.push.apply(data.rlevels, pageData.rlevels);
-    Array.prototype.push.apply(data.dlevels, pageData.dlevels);
-    Array.prototype.push.apply(data.values, pageData.values);
+    parquet_util.arrayCopy(data.rlevels, pageData.rlevels);
+    parquet_util.arrayCopy(data.dlevels, pageData.dlevels);
+    parquet_util.arrayCopy(data.values, pageData.values);
     data.count += pageData.count;
   }
-
 
   return data;
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -165,3 +165,9 @@ exports.fieldIndexOf = function(arr, elem) {
   return -1;
 }
 
+exports.arrayCopy = function(dest, src) {
+  const len = src.length
+  for(let i = 0; i < len; i++){
+    dest.push(src[i])
+  }
+}


### PR DESCRIPTION
When using consistently large values for a single column, the array,push(...) will cause a Maximum call stack exceeded error.  This also applies to Array.prototype.push.apply.  This change also increases the speed of the reader.